### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/test/Squirrel.Tests/TestHelpers/StaticHttpServer.cs
+++ b/test/Squirrel.Tests/TestHelpers/StaticHttpServer.cs
@@ -39,7 +39,12 @@ namespace Squirrel.Tests
                         return;
                     }
 
-                    var target = Path.Combine(RootPath, ctx.Request.Url.AbsolutePath.Replace('/', Path.DirectorySeparatorChar).Substring(1));
+                    var relativePath = ctx.Request.Url.AbsolutePath.Replace('/', Path.DirectorySeparatorChar).Substring(1);
+                    if (IsPathTraversal(relativePath)) {
+                        closeResponseWith(ctx, 400, "Invalid path");
+                        return;
+                    }
+                    var target = Path.Combine(RootPath, relativePath);
                     var fi = new FileInfo(target);
 
                     if (!fi.FullName.StartsWith(RootPath)) {
@@ -74,6 +79,11 @@ namespace Squirrel.Tests
 
             inner = ret;
             return ret;
+        }
+
+        private static bool IsPathTraversal(string path)
+        {
+            return path.Contains("..") || path.Contains(Path.DirectorySeparatorChar.ToString()) || path.Contains(Path.AltDirectorySeparatorChar.ToString());
         }
 
         static void closeResponseWith(HttpListenerContext ctx, int statusCode, string message)


### PR DESCRIPTION
Fixes [https://github.com/HyperCogWizard/Squirrel.Windows/security/code-scanning/2](https://github.com/HyperCogWizard/Squirrel.Windows/security/code-scanning/2)

To fix the problem, we need to validate the user input before using it to construct the file path. Specifically, we should ensure that the path does not contain any ".." sequences or path separators that could allow an attacker to traverse directories. Additionally, we should ensure that the resolved path is still within the intended `RootPath` directory.

1. Add a method to validate the user input path.
2. Use this method to check the `ctx.Request.Url.AbsolutePath` before constructing the `target` path.
3. If the validation fails, respond with an appropriate error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
