### PR TITLE
Fix code scanning alert no. 1: Cross-site scripting

### DIFF
--- a/test/Squirrel.Tests/TestHelpers/StaticHttpServer.cs
+++ b/test/Squirrel.Tests/TestHelpers/StaticHttpServer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net;
+using System.Net.WebUtility;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,7 +81,7 @@ namespace Squirrel.Tests
         {
             ctx.Response.StatusCode = statusCode;
             using (var sw = new StreamWriter(ctx.Response.OutputStream, Encoding.UTF8)) {
-                sw.WriteLine(message);
+                sw.WriteLine(WebUtility.HtmlEncode(message));
             }
             ctx.Response.Close();
         }


### PR DESCRIPTION
Fixes [https://github.com/HyperCogWizard/Squirrel.Windows/security/code-scanning/1](https://github.com/HyperCogWizard/Squirrel.Windows/security/code-scanning/1)

To fix the problem, we need to ensure that any user-provided input is properly sanitized before being written to the response stream. In this case, we can use the `System.Net.WebUtility.HtmlEncode` method to encode the user input, preventing any malicious scripts from being executed in the browser. We should apply this encoding to the error messages in the `closeResponseWith` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
